### PR TITLE
Fix conditional gem install

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -1,18 +1,19 @@
 name: Lint & Unit test
 
-'on':
+"on":
   workflow_call:
     inputs:
       gems:
         required: false
         type: string
+        default: ""
 
 jobs:
   rspec:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install Gems
@@ -25,7 +26,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
       - name: RSpec Report
-        uses: SonicGarden/rspec-report-action@v1
+        uses: SonicGarden/rspec-report-action@v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json-path: tmp/rspec_results.json
@@ -35,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Run Cookstyle
@@ -47,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run yaml Lint
         uses: actionshub/yamllint@main
 
@@ -55,6 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Markdown Lint
         uses: actionshub/markdownlint@main

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -6,7 +6,6 @@ name: Lint & Unit test
       gems:
         required: false
         type: string
-        default: ""
 
 jobs:
   rspec:
@@ -18,7 +17,7 @@ jobs:
         uses: actionshub/chef-install@main
       - name: Install Gems
         run: chef gem install -N "${{ inputs.gems }}"
-        if: ${{ inputs.gems }} != ""
+        if: ${{ github.event.inputs.gems != '' }}
         env:
           CHEF_LICENSE: accept-no-persist
       - name: Run RSpec


### PR DESCRIPTION
# Description

Fix conditional gem install

## Issues Resolved

Now skips the gem install step correctly

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
