### PR TITLE
Add option to switch platform RSpec is run on

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -7,10 +7,15 @@ name: Lint & Unit test
         required: false
         type: string
         default: ""
+      platform:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   rspec:
-    runs-on: ubuntu-latest
+    # Some RSpec tests require a Windows environment
+    runs-on: ${{ inputs.platform }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Always default the platform to ubuntu-latest

Signed-off-by: Dan Webb <dan.webb@damacus.io>
