### PR TITLE
allow the chef workstation version to be passed to install chef

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -11,6 +11,10 @@ name: Lint & Unit test
         required: false
         type: string
         default: "ubuntu-latest"
+      chef_workstation_version:
+        required: false
+        type: string
+        default: "latest"
 
 jobs:
   rspec:
@@ -21,6 +25,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@2.0.4
+        with:
+          version: ${{ inputs.chef_workstation_version }}
       - name: Install Gems
         run: chef gem install -N "${{ inputs.gems }}"
         if: ${{ inputs.gems }}
@@ -44,6 +50,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@2.0.4
+        with:
+          version: ${{ inputs.chef_workstation_version }}
       - name: Run Cookstyle
         run: chef exec cookstyle --display-cop-names --extra-details
         env:


### PR DESCRIPTION
# Description
add input for specifying the chef workstation version for the github action that installs workstation

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.