### PR TITLE
fix: optimize lint-unit workflow with bundler and chefspec pin

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -35,11 +35,13 @@ jobs:
       - name: Prepare Gemfile
         run: |
           if [ ! -f Gemfile ]; then
-            echo "source 'https://rubygems.org'" > Gemfile
-            echo "gem 'chefspec', '>= 9.3.7'" >> Gemfile
-            echo "gem 'berkshelf'" >> Gemfile
-            echo "gem 'fauxhai-chef'" >> Gemfile
-            echo "gem 'rspec-its'" >> Gemfile
+            {
+              echo "source 'https://rubygems.org'"
+              echo "gem 'chefspec', '>= 9.3.7'"
+              echo "gem 'berkshelf'"
+              echo "gem 'fauxhai-chef'"
+              echo "gem 'rspec-its'"
+            } > Gemfile
             if [ -f metadata.rb ]; then
               grep "^gem " metadata.rb >> Gemfile || true
             fi
@@ -75,8 +77,10 @@ jobs:
       - name: Prepare Gemfile
         run: |
           if [ ! -f Gemfile ]; then
-            echo "source 'https://rubygems.org'" > Gemfile
-            echo "gem 'cookstyle'" >> Gemfile
+            {
+              echo "source 'https://rubygems.org'"
+              echo "gem 'cookstyle'"
+            } > Gemfile
           fi
         shell: bash
       - name: Setup Ruby

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -15,10 +15,6 @@ name: Lint & Unit test
         required: false
         type: string
         default: "ubuntu-latest"
-      chef_workstation_version:
-        required: false
-        type: string
-        default: "latest"
       fail_on_link_errors:
         required: false
         type: boolean
@@ -40,7 +36,7 @@ jobs:
         run: |
           if [ ! -f Gemfile ]; then
             echo "source 'https://rubygems.org'" > Gemfile
-            echo "gem 'chefspec'" >> Gemfile
+            echo "gem 'chefspec', '>= 9.3.7'" >> Gemfile
             echo "gem 'berkshelf'" >> Gemfile
             echo "gem 'fauxhai-chef'" >> Gemfile
             echo "gem 'rspec-its'" >> Gemfile
@@ -57,7 +53,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RSpec
         run: |
@@ -86,7 +82,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run Cookstyle
         run: |

--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -36,22 +36,32 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+      - name: Prepare Gemfile
+        run: |
+          if [ ! -f Gemfile ]; then
+            echo "source 'https://rubygems.org'" > Gemfile
+            echo "gem 'chefspec'" >> Gemfile
+            echo "gem 'berkshelf'" >> Gemfile
+            echo "gem 'fauxhai-chef'" >> Gemfile
+            echo "gem 'rspec-its'" >> Gemfile
+            if [ -f metadata.rb ]; then
+              grep "^gem " metadata.rb >> Gemfile || true
+            fi
+            if [ -n "${{ inputs.gems }}" ]; then
+              for g in ${{ inputs.gems }}; do
+                echo "gem '$g'" >> Gemfile
+              done
+            fi
+          fi
+        shell: bash
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.2"
           bundler-cache: true
-      - name: Install extra gems
-        run: gem install -N "${{ inputs.gems }}"
-        if: ${{ inputs.gems }}
       - name: Run RSpec
         run: |
-          if [ -f Gemfile ]; then
-            bundle exec rspec -f j -o tmp/rspec_results.json -f p
-          else
-            gem install -N chefspec
-            rspec -f j -o tmp/rspec_results.json -f p
-          fi
+          bundle exec rspec -f j -o tmp/rspec_results.json -f p
         shell: bash
       - name: RSpec Report
         uses: SonicGarden/rspec-report-action@v6
@@ -66,19 +76,21 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+      - name: Prepare Gemfile
+        run: |
+          if [ ! -f Gemfile ]; then
+            echo "source 'https://rubygems.org'" > Gemfile
+            echo "gem 'cookstyle'" >> Gemfile
+          fi
+        shell: bash
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Run Cookstyle
         run: |
-          if [ -f Gemfile ]; then
-            bundle exec cookstyle --display-cop-names --extra-details
-          else
-            gem install -N cookstyle
-            cookstyle --display-cop-names --extra-details
-          fi
+          bundle exec cookstyle --display-cop-names --extra-details
         shell: bash
 
   check-yaml:


### PR DESCRIPTION
## Summary
- Generate a Gemfile dynamically for cookbooks that don't have one, using bundler for proper dependency resolution instead of raw `gem install`
- Pin `chefspec >= 9.3.7` to avoid the broken 9.3.6 release (requires `rspec/matchers/expecteds_for_multiple_diffs` which was renamed in rspec-expectations 3.13.0)
- Restore Ruby 3.3 (was accidentally downgraded to 3.2)
- Remove unused `chef_workstation_version` input
- Simplify rspec/cookstyle steps to always use `bundle exec`

## Test plan
- [x] Verified bundler resolves chefspec 9.3.8 + rspec-expectations 3.12.3
- [x] Ran LVM cookbook specs locally: 31 examples, 0 failures
- [ ] CI passes on this repo
- [ ] Test with sous-chefs/lvm by pointing ci.yml at this branch