### PR TITLE
fix: pin workflow ruby to chef workstation

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.2" # Match Chef Workstation 25's bundled Ruby
           bundler-cache: true
       - name: Run RSpec
         run: |
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.2" # Match Chef Workstation 25's bundled Ruby
           bundler-cache: true
       - name: Run Cookstyle
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "packageRules": [{
+      "description": "Chef Workstation 25 bundles Ruby 3.2, so keep setup-ruby pinned to that line",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["uses-with"],
+      "matchPackageNames": ["ruby"],
+      "enabled": false
+    },
+    {
       "groupName": "Actions",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true,


### PR DESCRIPTION
## Summary
- keep `ruby/setup-ruby` pinned to `3.2` to match Chef Workstation 25
- disable Renovate updates for the `ruby` `uses-with` dependency in GitHub Actions workflows
- add inline context so future updates do not drift from the workstation runtime

## Context
PR #60 proposed bumping the workflow Ruby runtime, but these workflows need to stay aligned with Chef Workstation 25, which is Ruby 3.2.