### PR TITLE
ci: allow linkspector check to fail

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -116,6 +116,8 @@ jobs:
   check-links:
     name: runner / linkspector
     runs-on: ubuntu-latest
+    # TODO: Allowed to fail due to https://github.com/UmbrellaDocs/action-linkspector/issues/62
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Run linkspector


### PR DESCRIPTION
Work around upstream issue that blocks all action runs by setting
continue-on-error on the check-links job.

Refs: https://github.com/UmbrellaDocs/action-linkspector/issues/62

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves.

## Issues Resolved

List any existing issues this PR resolves.

## Check List

- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
