### PR TITLE
feat!: publish cookbooks with cinc-cli

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.2" # Match Chef Workstation 25's bundled Ruby
           bundler-cache: true
       - name: Run RSpec
         run: |
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.2" # Match Chef Workstation 25's bundled Ruby
           bundler-cache: true
       - name: Run Cookstyle
         run: |

--- a/.github/workflows/release-cookbook.yml
+++ b/.github/workflows/release-cookbook.yml
@@ -58,25 +58,54 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
-    container:
-      image: chef/chefworkstation:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Configure Chef credentials
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.3"
+
+      - name: Install cinc
         run: |
-          mkdir -p ~/.chef
-          echo "${{ secrets.supermarket_key }}" > ~/.chef/supermarket.pem
-          chmod 600 ~/.chef/supermarket.pem
+          GOBIN="${RUNNER_TEMP}/bin" go install github.com/tas50/cinc-cli/apps/cinc@v0.6.1
+          sudo install "${RUNNER_TEMP}/bin/cinc" /usr/local/bin/cinc
+          cinc version
+        shell: bash
+
+      - name: Configure Cinc credentials
+        run: |
+          mkdir -p ~/.cinc
+          key_path="${HOME}/.cinc/supermarket.pem"
+          credentials_path="${HOME}/.cinc/credentials"
+          printf '%s\n' "${{ secrets.supermarket_key }}" > "${key_path}"
+          chmod 600 "${key_path}"
+          {
+            echo "[default]"
+            echo 'supermarket_site = "https://supermarket.chef.io"'
+            printf 'client_name = "%s"\n' "${{ secrets.supermarket_user }}"
+            printf 'client_key = "%s"\n' "${key_path}"
+          } > "${credentials_path}"
+          chmod 600 "${credentials_path}"
+        shell: bash
+
+      - name: Validate Supermarket package
+        run: |
+          cinc supermarket share ${{ github.event.repository.name }} \
+            --dry-run \
+            --cookbook-path ../ \
+            --config ~/.cinc/credentials \
+            --format json
+        shell: bash
 
       - name: Publish to Chef Supermarket
         run: |
-          knife supermarket share ${{ github.event.repository.name }} \
+          cinc supermarket share ${{ github.event.repository.name }} \
             --supermarket-site https://supermarket.chef.io \
-            --key ~/.chef/supermarket.pem \
-            --user ${{ secrets.supermarket_user }} \
-            --cookbook-path ../
+            --cookbook-path ../ \
+            --config ~/.cinc/credentials
+        shell: bash
 
   notify-slack:
     needs: [release-please, publish-to-supermarket]

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "packageRules": [{
+      "description": "Chef Workstation 25 bundles Ruby 3.2, so keep setup-ruby pinned to that line",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["uses-with"],
+      "matchPackageNames": ["ruby"],
+      "enabled": false
+    },
+    {
       "groupName": "Actions",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true,


### PR DESCRIPTION
## Summary

- replace Chef Workstation/knife Supermarket publishing with pinned `go install` of cinc-cli v0.6.1
- write Cinc credentials from the existing Supermarket reusable workflow secrets
- add a dry-run cookbook packaging validation before upload

## Verification

- `actionlint`
- `yamllint .github/workflows/release-cookbook.yml`
- `git diff --check`

## Follow-up

- after merge, publish shared workflow tag `6.0.1` for cookbook repos to consume
