### PR TITLE
fix: make linkspector opt-in

### DIFF
--- a/.github/workflows/lint-unit.yml
+++ b/.github/workflows/lint-unit.yml
@@ -15,6 +15,10 @@ name: Lint & Unit test
         required: false
         type: string
         default: "ubuntu-latest"
+      run_linkspector:
+        required: false
+        type: boolean
+        default: false
       fail_on_link_errors:
         required: false
         type: boolean
@@ -116,6 +120,7 @@ jobs:
   check-links:
     name: runner / linkspector
     runs-on: ubuntu-latest
+    if: ${{ inputs.run_linkspector }}
     # TODO: Allowed to fail due to https://github.com/UmbrellaDocs/action-linkspector/issues/62
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Summary
- Add a reusable workflow input to control the linkspector job
- Default linkspector to disabled so current callers stop running the broken action
- Keep existing reporter and fail-on-error inputs for callers that opt back in

## Testing
- ruby YAML load for .github/workflows/lint-unit.yml
- git diff --check