### PR TITLE
ci: trust renovate workflow updates

### DIFF
--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -13,7 +13,7 @@ name: "Prevent file change reusable"
         description: Comma-separated list of trusted authors for metadata changes
         required: false
         type: string
-        default: bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima
+        default: &trusted_authors "bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima,renovate[bot]"
       workflow_pattern:
         description: Pattern of workflow files to monitor
         required: false
@@ -23,7 +23,7 @@ name: "Prevent file change reusable"
         description: Comma-separated list of trusted authors for workflow changes
         required: false
         type: string
-        default: bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima
+        default: *trusted_authors
       workflow_close_pr:
         description: Close the PR if workflow files change
         required: false


### PR DESCRIPTION
Update the reusable prevent-file-change workflow defaults so metadata and workflow trusted authors share the same YAML-anchored value.\n\nThis adds renovate[bot] centrally, allowing consumer repositories to remove local workflow_trusted_authors overrides and inherit the shared policy.