### PR TITLE
ci: pin install-workstation action

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.1
 
       - name: markdownlint-cli2-action
         uses: DavidAnson/markdownlint-cli2-action@v23


### PR DESCRIPTION
Pin the central copilot setup workflow to sous-chefs/.github/.github/actions/install-workstation@8.0.1 instead of tracking main.