### PR TITLE
fix: correct cinc-cli tar extraction in release workflow

### DIFF
--- a/.github/workflows/release-cookbook.yml
+++ b/.github/workflows/release-cookbook.yml
@@ -64,11 +64,13 @@ jobs:
 
       - name: Install cinc
         env:
-          CINC_VERSION: v0.8.0
+          GH_TOKEN: ${{ github.token }}
         run: |
+          CINC_VERSION=$(gh release view --repo tas50/cinc-cli --json tagName -q .tagName)
+          echo "Installing cinc ${CINC_VERSION}"
           url="https://github.com/tas50/cinc-cli/releases/download/${CINC_VERSION}/cinc_${CINC_VERSION}_linux_amd64.tar.gz"
           curl -fsSL "${url}" -o "${RUNNER_TEMP}/cinc.tar.gz"
-          tar -xzf "${RUNNER_TEMP}/cinc.tar.gz" -C "${RUNNER_TEMP}" cinc
+          tar -xzf "${RUNNER_TEMP}/cinc.tar.gz" -C "${RUNNER_TEMP}" --strip-components=1
           sudo install "${RUNNER_TEMP}/cinc" /usr/local/bin/cinc
           cinc version
         shell: bash


### PR DESCRIPTION
## Problem

The `Install cinc` step in the `release-cookbook.yml` workflow fails with exit code 2:

```
tar: cinc: Not found in archive
tar: Exiting with failure status due to previous errors
```

**Root cause:** The `tar` command tries to extract a member named `cinc` from the archive root, but all cinc-cli release tarballs wrap the binary in a versioned directory:

```
cinc_v0.8.0_linux_amd64/
└── cinc
```

So `tar -xzf ... cinc` fails because there is no top-level `cinc` member.

**Affected run:** https://github.com/sous-chefs/lvm/actions/runs/27562914314/job/81480238320

## Fix

1. **`--strip-components=1`** — Strips the versioned directory prefix during extraction, placing the `cinc` binary directly into `$RUNNER_TEMP` where `sudo install` expects it.

2. **Dynamic version resolution** — Replaces the hardcoded `CINC_VERSION: v0.8.0` env var with a runtime lookup using `gh release view --repo tas50/cinc-cli`. This ensures we always install the latest release without needing manual version bumps.

## Verification

Confirmed archive structure is consistent across all releases (v0.1.0 through v0.10.1):
```bash
$ curl -fsSL '...cinc_v0.8.0_linux_amd64.tar.gz' | tar -tzf -
cinc_v0.8.0_linux_amd64/
cinc_v0.8.0_linux_amd64/cinc

$ curl -fsSL '...cinc_v0.10.1_linux_amd64.tar.gz' | tar -tzf -
cinc_v0.10.1_linux_amd64/
cinc_v0.10.1_linux_amd64/cinc
```