### PR TITLE
refactor: split workstation composite action

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,32 @@
+# Composite Action Structure
+
+Keep composite actions as orchestration. Put non-trivial bash or PowerShell in
+scripts next to the action so it can be linted and tested directly.
+
+Recommended layout:
+
+```text
+.github/actions/<action-name>/
+  action.yml
+  scripts/
+    <focused-step>.sh
+    <focused-step>.ps1
+```
+
+Use small, named composite steps that call those scripts through
+`$GITHUB_ACTION_PATH`. Avoid composing sibling local actions from a published
+remote action because relative `uses:` paths are resolved from the caller's
+checkout.
+
+Each action should include focused checks for its implementation scripts:
+
+- YAML validation through actionlint.
+- Bash validation through shellcheck.
+- PowerShell parser validation for `.ps1` files.
+- Contract tests for action-specific expectations that are easy to break while
+  refactoring.
+
+Actions that install tools should also expose debuggable outputs such as the
+selected distribution, resolved version, executable name, executable path, and
+related command paths. Tests should assert those outputs exist so consumers can
+rely on them in follow-up workflow steps.

--- a/.github/actions/install-workstation/action.yml
+++ b/.github/actions/install-workstation/action.yml
@@ -1,16 +1,22 @@
 ---
-name: Install Cinc Workstation
+name: Install Cinc
 author: Sous Chefs
 description: >
-  Installs Cinc Workstation (open-source Chef Workstation distribution) on the
-  GitHub Actions runner. Replaces actionshub/chef-install to avoid omnitruck.chef.io
-  checksum mismatch failures. Cinc includes `chef` command wrappers for full compatibility.
+  Installs Cinc Workstation by default, or the experimental Cinc CLI when
+  explicitly requested. Cinc Workstation includes `chef` command wrappers for
+  full compatibility.
 
 inputs:
+  distribution:
+    description: >
+      Cinc distribution to install. Use `workstation` for Cinc Workstation, or
+      `cinc-cli` for the experimental standalone Cinc CLI.
+    required: false
+    default: workstation
   version:
     description: >
-      Cinc Workstation version to install. Use major version (e.g. '24') for latest
-      in that series, or 'latest' for the newest stable release.
+      Version to install. For Workstation, use a major version such as `24` or
+      `latest`. For Cinc CLI, use a tag such as `v0.11.0` or `latest`.
     required: false
     default: 'latest'
   channel:
@@ -18,47 +24,99 @@ inputs:
     required: false
     default: 'stable'
 
+outputs:
+  distribution:
+    description: Installed Cinc distribution.
+    value: ${{ steps.outputs-unix.outputs.distribution || steps.outputs-windows.outputs.distribution }}
+  version:
+    description: Installed Cinc version reported by the selected executable.
+    value: ${{ steps.outputs-unix.outputs.version || steps.outputs-windows.outputs.version }}
+  requested_version:
+    description: Version requested by the action input after resolving defaults.
+    value: ${{ steps.resolve.outputs.requested_version }}
+  channel:
+    description: Release channel requested for Workstation installs.
+    value: ${{ steps.resolve.outputs.channel }}
+  runner_os:
+    description: GitHub Actions runner OS used by the action.
+    value: ${{ steps.resolve.outputs.runner_os }}
+  runner_arch:
+    description: GitHub Actions runner architecture used by the action.
+    value: ${{ steps.resolve.outputs.runner_arch }}
+  executable:
+    description: Primary executable installed by this action.
+    value: ${{ steps.outputs-unix.outputs.executable || steps.outputs-windows.outputs.executable }}
+  executable_path:
+    description: Path to the primary executable.
+    value: ${{ steps.outputs-unix.outputs.executable_path || steps.outputs-windows.outputs.executable_path }}
+  cinc_path:
+    description: Path to `cinc`, when available.
+    value: ${{ steps.outputs-unix.outputs.cinc_path || steps.outputs-windows.outputs.cinc_path }}
+  chef_path:
+    description: Path to `chef`, when available.
+    value: ${{ steps.outputs-unix.outputs.chef_path || steps.outputs-windows.outputs.chef_path }}
+  knife_path:
+    description: Path to `knife`, when available.
+    value: ${{ steps.outputs-unix.outputs.knife_path || steps.outputs-windows.outputs.knife_path }}
+
 runs:
   using: composite
   steps:
-    - name: Install Cinc Workstation (Linux/macOS)
-      if: runner.os != 'Windows'
+    # Keep this composite action as orchestration. The platform-specific
+    # behavior lives in scripts so it can be linted and tested outside Actions.
+    - name: Resolve Cinc install inputs
+      id: resolve
       shell: bash
-      run: |
-        set -euo pipefail
-        echo "::group::Installing Cinc Workstation v${{ inputs.version }}"
-        curl -fsSL https://omnitruck.cinc.sh/install.sh \
-          | sudo bash -s -- -P cinc-workstation -c ${{ inputs.channel }} -v ${{ inputs.version }}
-        echo "::endgroup::"
+      env:
+        CINC_DISTRIBUTION: ${{ inputs.distribution }}
+        CINC_VERSION: ${{ inputs.version }}
+        CINC_CHANNEL: ${{ inputs.channel }}
+        GH_TOKEN: ${{ github.token }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/resolve-inputs.sh"
 
-        # Verify installation
-        cinc --version || chef --version
+    - name: Install Cinc Workstation (Linux/macOS)
+      if: steps.resolve.outputs.distribution == 'workstation' && runner.os != 'Windows'
+      shell: bash
+      env:
+        CINC_CHANNEL: ${{ steps.resolve.outputs.channel }}
+        CINC_VERSION: ${{ steps.resolve.outputs.requested_version }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/install-unix.sh"
 
     - name: Install Cinc Workstation (Windows)
+      if: steps.resolve.outputs.distribution == 'workstation' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CINC_CHANNEL: ${{ steps.resolve.outputs.channel }}
+        CINC_VERSION: ${{ steps.resolve.outputs.requested_version }}
+      run: '& "$env:GITHUB_ACTION_PATH/scripts/install-windows.ps1"'
+
+    - name: Install Cinc CLI (Linux/macOS)
+      if: steps.resolve.outputs.distribution == 'cinc-cli'
+      shell: bash
+      env:
+        CINC_VERSION: ${{ steps.resolve.outputs.requested_version }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/install-cinc-cli.sh"
+
+    - name: Refresh Cinc Workstation PATH (Windows)
+      if: steps.resolve.outputs.distribution == 'workstation' && runner.os == 'Windows'
+      shell: pwsh
+      run: '& "$env:GITHUB_ACTION_PATH/scripts/refresh-windows-path.ps1"'
+
+    - name: Resolve Cinc action outputs (Linux/macOS)
+      id: outputs-unix
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        CINC_DISTRIBUTION: ${{ steps.resolve.outputs.distribution }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/outputs-unix.sh"
+
+    - name: Resolve Cinc action outputs (Windows)
+      id: outputs-windows
       if: runner.os == 'Windows'
       shell: pwsh
-      run: |
-        Write-Host "::group::Installing Cinc Workstation v${{ inputs.version }}"
-        . { iwr -useb https://omnitruck.cinc.sh/install.ps1 } | iex
-        install -project cinc-workstation -channel ${{ inputs.channel }} -version ${{ inputs.version }}
-        Write-Host "::endgroup::"
-
-        # The MSI updates the registry PATH but not the current session.
-        # Refresh it so we can verify immediately, then persist to GITHUB_PATH
-        # so subsequent steps can find chef/cinc without their own refresh.
-        $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
-        $userPath    = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-        $env:PATH    = "$machinePath;$userPath"
-
-        # Persist the Cinc bin dir for all later steps
-        $cincBin = (Get-Command cinc -ErrorAction SilentlyContinue)?.Source |
-                   Split-Path -Parent
-        if ($cincBin) {
-          "$cincBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        }
-
-        # Verify installation in the same session where PATH is already refreshed
-        cinc --version
+      env:
+        CINC_DISTRIBUTION: ${{ steps.resolve.outputs.distribution }}
+      run: '& "$env:GITHUB_ACTION_PATH/scripts/outputs-windows.ps1"'
 
 branding:
   icon: download

--- a/.github/actions/install-workstation/scripts/install-cinc-cli.sh
+++ b/.github/actions/install-workstation/scripts/install-cinc-cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${RUNNER_OS:-}" in
+  Linux)
+    platform="linux"
+    ;;
+  macOS)
+    platform="darwin"
+    ;;
+  *)
+    echo "::error::cinc-cli installation currently supports Linux and macOS runners only." >&2
+    exit 1
+    ;;
+esac
+
+case "${RUNNER_ARCH:-}" in
+  X64)
+    arch="amd64"
+    ;;
+  ARM64)
+    arch="arm64"
+    ;;
+  *)
+    echo "::error::Unsupported runner architecture for cinc-cli: ${RUNNER_ARCH:-unknown}" >&2
+    exit 1
+    ;;
+esac
+
+archive="cinc_${CINC_VERSION}_${platform}_${arch}.tar.gz"
+url="https://github.com/tas50/cinc-cli/releases/download/${CINC_VERSION}/${archive}"
+
+echo "::group::Installing Cinc CLI ${CINC_VERSION}"
+echo "runner_os=${RUNNER_OS:-unknown}"
+echo "runner_arch=${RUNNER_ARCH:-unknown}"
+echo "platform=${platform}"
+echo "arch=${arch}"
+echo "installer=${url}"
+echo "archive=${RUNNER_TEMP}/${archive}"
+
+curl -fsSL "${url}" -o "${RUNNER_TEMP}/${archive}"
+tar -xzf "${RUNNER_TEMP}/${archive}" \
+  -C "${RUNNER_TEMP}" \
+  --strip-components=1 \
+  "cinc_${CINC_VERSION}_${platform}_${arch}/cinc"
+sudo install "${RUNNER_TEMP}/cinc" /usr/local/bin/cinc
+cinc version
+echo "::endgroup::"

--- a/.github/actions/install-workstation/scripts/install-unix.sh
+++ b/.github/actions/install-workstation/scripts/install-unix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Installing Cinc Workstation v${CINC_VERSION}"
+echo "channel=${CINC_CHANNEL}"
+echo "installer=https://omnitruck.cinc.sh/install.sh"
+curl -fsSL https://omnitruck.cinc.sh/install.sh |
+  sudo bash -s -- -P cinc-workstation -c "${CINC_CHANNEL}" -v "${CINC_VERSION}"
+echo "::endgroup::"

--- a/.github/actions/install-workstation/scripts/install-windows.ps1
+++ b/.github/actions/install-workstation/scripts/install-windows.ps1
@@ -1,0 +1,9 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host "::group::Installing Cinc Workstation v$env:CINC_VERSION"
+Write-Host "channel=$env:CINC_CHANNEL"
+Write-Host 'installer=https://omnitruck.cinc.sh/install.ps1'
+. { Invoke-WebRequest -UseBasicParsing https://omnitruck.cinc.sh/install.ps1 } | Invoke-Expression
+install -project cinc-workstation -channel $env:CINC_CHANNEL -version $env:CINC_VERSION
+Write-Host '::endgroup::'

--- a/.github/actions/install-workstation/scripts/outputs-unix.sh
+++ b/.github/actions/install-workstation/scripts/outputs-unix.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+resolve_command() {
+  local command_name="$1"
+
+  command -v "${command_name}" 2>/dev/null || true
+}
+
+emit_output() {
+  local key="$1"
+  local value="$2"
+
+  printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
+}
+
+cinc_path="$(resolve_command cinc)"
+chef_path="$(resolve_command chef)"
+knife_path="$(resolve_command knife)"
+
+case "${CINC_DISTRIBUTION}" in
+  workstation)
+    if [ -n "${chef_path}" ]; then
+      executable="chef"
+      executable_path="${chef_path}"
+    else
+      executable="cinc"
+      executable_path="${cinc_path}"
+    fi
+    ;;
+  cinc-cli)
+    executable="cinc"
+    executable_path="${cinc_path}"
+    ;;
+  *)
+    echo "::error::Unsupported distribution for output resolution: ${CINC_DISTRIBUTION}" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "${executable_path}" ]; then
+  echo "::error::Could not find ${executable} in PATH." >&2
+  exit 1
+fi
+
+version_output="$("${executable_path}" --version 2>/dev/null || "${executable_path}" version)"
+version="$(printf '%s\n' "${version_output}" | head -n 1)"
+
+echo "::group::Resolved Cinc action outputs"
+echo "distribution=${CINC_DISTRIBUTION}"
+echo "executable=${executable}"
+echo "executable_path=${executable_path}"
+echo "cinc_path=${cinc_path}"
+echo "chef_path=${chef_path}"
+echo "knife_path=${knife_path}"
+echo "version=${version}"
+
+emit_output "distribution" "${CINC_DISTRIBUTION}"
+emit_output "executable" "${executable}"
+emit_output "executable_path" "${executable_path}"
+emit_output "cinc_path" "${cinc_path}"
+emit_output "chef_path" "${chef_path}"
+emit_output "knife_path" "${knife_path}"
+emit_output "version" "${version}"
+echo "::endgroup::"

--- a/.github/actions/install-workstation/scripts/outputs-unix.sh
+++ b/.github/actions/install-workstation/scripts/outputs-unix.sh
@@ -14,6 +14,16 @@ emit_output() {
   printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
 }
 
+resolve_version() {
+  local version_output
+
+  if ! version_output="$("${executable_path}" --version 2>&1)"; then
+    version_output="$("${executable_path}" version 2>&1)"
+  fi
+
+  printf '%s\n' "${version_output}" | awk 'NF && $0 != "Redirecting to cinc" { print; exit }'
+}
+
 cinc_path="$(resolve_command cinc)"
 chef_path="$(resolve_command chef)"
 knife_path="$(resolve_command knife)"
@@ -43,8 +53,12 @@ if [ -z "${executable_path}" ]; then
   exit 1
 fi
 
-version_output="$("${executable_path}" --version 2>/dev/null || "${executable_path}" version)"
-version="$(printf '%s\n' "${version_output}" | head -n 1)"
+version="$(resolve_version)"
+
+if [ -z "${version}" ]; then
+  echo "::error::Could not resolve ${executable} version." >&2
+  exit 1
+fi
 
 echo "::group::Resolved Cinc action outputs"
 echo "distribution=${CINC_DISTRIBUTION}"

--- a/.github/actions/install-workstation/scripts/outputs-windows.ps1
+++ b/.github/actions/install-workstation/scripts/outputs-windows.ps1
@@ -21,6 +21,27 @@ function Add-ActionOutput {
   "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 }
 
+function Resolve-ExecutableVersion {
+  param([string] $Path)
+
+  $versionOutput = & $Path --version 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $versionOutput = & $Path version 2>&1
+  }
+
+  $version = $versionOutput |
+    ForEach-Object { $_.ToString() } |
+    Where-Object { $_ -and $_ -ne 'Redirecting to cinc' } |
+    Select-Object -First 1
+
+  if (-not $version) {
+    Write-Error "Could not resolve $executable version."
+    exit 1
+  }
+
+  return $version
+}
+
 $cincPath = Resolve-CommandPath -Name cinc
 $chefPath = Resolve-CommandPath -Name chef
 $knifePath = Resolve-CommandPath -Name knife
@@ -46,7 +67,7 @@ if (-not $executablePath) {
   exit 1
 }
 
-$version = (& $executablePath --version | Select-Object -First 1)
+$version = Resolve-ExecutableVersion -Path $executablePath
 
 Write-Host '::group::Resolved Cinc action outputs'
 Write-Host "distribution=$env:CINC_DISTRIBUTION"

--- a/.github/actions/install-workstation/scripts/outputs-windows.ps1
+++ b/.github/actions/install-workstation/scripts/outputs-windows.ps1
@@ -1,0 +1,67 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-CommandPath {
+  param([string] $Name)
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if ($command) {
+    return $command.Source
+  }
+
+  return ''
+}
+
+function Add-ActionOutput {
+  param(
+    [string] $Name,
+    [string] $Value
+  )
+
+  "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+$cincPath = Resolve-CommandPath -Name cinc
+$chefPath = Resolve-CommandPath -Name chef
+$knifePath = Resolve-CommandPath -Name knife
+
+switch ($env:CINC_DISTRIBUTION) {
+  'workstation' {
+    if ($chefPath) {
+      $executable = 'chef'
+      $executablePath = $chefPath
+    } else {
+      $executable = 'cinc'
+      $executablePath = $cincPath
+    }
+  }
+  default {
+    Write-Error "Unsupported distribution for Windows output resolution: $env:CINC_DISTRIBUTION"
+    exit 1
+  }
+}
+
+if (-not $executablePath) {
+  Write-Error "$executable was not found in PATH."
+  exit 1
+}
+
+$version = (& $executablePath --version | Select-Object -First 1)
+
+Write-Host '::group::Resolved Cinc action outputs'
+Write-Host "distribution=$env:CINC_DISTRIBUTION"
+Write-Host "executable=$executable"
+Write-Host "executable_path=$executablePath"
+Write-Host "cinc_path=$cincPath"
+Write-Host "chef_path=$chefPath"
+Write-Host "knife_path=$knifePath"
+Write-Host "version=$version"
+
+Add-ActionOutput -Name distribution -Value $env:CINC_DISTRIBUTION
+Add-ActionOutput -Name executable -Value $executable
+Add-ActionOutput -Name executable_path -Value $executablePath
+Add-ActionOutput -Name cinc_path -Value $cincPath
+Add-ActionOutput -Name chef_path -Value $chefPath
+Add-ActionOutput -Name knife_path -Value $knifePath
+Add-ActionOutput -Name version -Value $version
+Write-Host '::endgroup::'

--- a/.github/actions/install-workstation/scripts/refresh-windows-path.ps1
+++ b/.github/actions/install-workstation/scripts/refresh-windows-path.ps1
@@ -1,0 +1,17 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# The MSI updates the registry PATH but not the current session.
+$machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+$userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+$env:PATH = "$machinePath;$userPath"
+
+$cincBin = (Get-Command cinc -ErrorAction SilentlyContinue)?.Source |
+  Split-Path -Parent
+
+if ($cincBin) {
+  Write-Host "Adding Cinc bin directory to GITHUB_PATH: $cincBin"
+  $cincBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+} else {
+  Write-Host 'Cinc command was not found while refreshing PATH.'
+}

--- a/.github/actions/install-workstation/scripts/resolve-inputs.sh
+++ b/.github/actions/install-workstation/scripts/resolve-inputs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+distribution="${CINC_DISTRIBUTION}"
+version="${CINC_VERSION}"
+channel="${CINC_CHANNEL}"
+
+echo "::group::Resolving Cinc install inputs"
+echo "distribution=${distribution}"
+echo "version=${version}"
+echo "channel=${channel}"
+echo "runner_os=${RUNNER_OS:-unknown}"
+echo "runner_arch=${RUNNER_ARCH:-unknown}"
+
+case "${distribution}" in
+  workstation|cinc-cli)
+    ;;
+  *)
+    echo "::error::distribution must be 'workstation' or 'cinc-cli'." >&2
+    exit 1
+    ;;
+esac
+
+if [ "${distribution}" = "cinc-cli" ] && [ "${RUNNER_OS:-}" != "Linux" ] && [ "${RUNNER_OS:-}" != "macOS" ]; then
+  echo "::error::cinc-cli installation currently supports Linux and macOS runners only." >&2
+  exit 1
+fi
+
+if [ "${distribution}" = "cinc-cli" ] && [ "${version}" = "latest" ]; then
+  echo "Resolving latest cinc-cli release with gh."
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::gh is required to resolve latest cinc-cli release." >&2
+    exit 1
+  fi
+
+  version="$(gh release view --repo tas50/cinc-cli --json tagName -q .tagName)"
+  echo "Resolved cinc-cli latest to ${version}"
+fi
+
+{
+  echo "distribution=${distribution}"
+  echo "requested_version=${version}"
+  echo "channel=${channel}"
+  echo "runner_os=${RUNNER_OS:-unknown}"
+  echo "runner_arch=${RUNNER_ARCH:-unknown}"
+} >> "${GITHUB_OUTPUT}"
+
+echo "::endgroup::"

--- a/.github/actions/install-workstation/tests/check-script-contracts.sh
+++ b/.github/actions/install-workstation/tests/check-script-contracts.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+action_file="${action_dir}/action.yml"
+scripts_dir="${action_dir}/scripts"
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+
+  echo "Checking ${file} contains: ${pattern}"
+  if ! grep -Fq -- "${pattern}" "${file}"; then
+    echo "::error file=${file}::Expected to find: ${pattern}" >&2
+    return 1
+  fi
+}
+
+assert_output() {
+  local file="$1"
+  local key="$2"
+  local expected="$3"
+
+  echo "Checking ${file} output ${key}=${expected}"
+  if ! grep -Fxq -- "${key}=${expected}" "${file}"; then
+    echo "::error file=${file}::Expected output ${key}=${expected}" >&2
+    echo "Actual outputs:" >&2
+    sed -n '1,120p' "${file}" >&2
+    return 1
+  fi
+}
+
+run_outputs_unix_contract() {
+  local distribution="$1"
+  local expected_version="$2"
+  local expected_executable="$3"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "${tmpdir}"' RETURN
+
+  mkdir -p "${tmpdir}/bin"
+
+  cat > "${tmpdir}/bin/cinc" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version|version)
+    echo "cinc 0.11.0"
+    ;;
+  *)
+    echo "unexpected cinc arguments: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+  cat > "${tmpdir}/bin/chef" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version|version)
+    echo "Chef Workstation 25.0.0"
+    ;;
+  *)
+    echo "unexpected chef arguments: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+  cat > "${tmpdir}/bin/knife" <<'EOF'
+#!/usr/bin/env bash
+echo "knife 25.0.0"
+EOF
+
+  chmod +x "${tmpdir}/bin/cinc" "${tmpdir}/bin/chef" "${tmpdir}/bin/knife"
+
+  local output_file="${tmpdir}/outputs"
+  PATH="${tmpdir}/bin:${PATH}" \
+    GITHUB_OUTPUT="${output_file}" \
+    CINC_DISTRIBUTION="${distribution}" \
+    bash "${scripts_dir}/outputs-unix.sh"
+
+  assert_output "${output_file}" "distribution" "${distribution}"
+  assert_output "${output_file}" "version" "${expected_version}"
+  assert_output "${output_file}" "executable" "${expected_executable}"
+  assert_output "${output_file}" "executable_path" "${tmpdir}/bin/${expected_executable}"
+  assert_output "${output_file}" "cinc_path" "${tmpdir}/bin/cinc"
+  assert_output "${output_file}" "chef_path" "${tmpdir}/bin/chef"
+  assert_output "${output_file}" "knife_path" "${tmpdir}/bin/knife"
+}
+
+run_resolve_inputs_contract() {
+  local distribution="$1"
+  local version="$2"
+  local expected_version="$3"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "${tmpdir}"' RETURN
+
+  mkdir -p "${tmpdir}/bin"
+
+  cat > "${tmpdir}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "$*" = "release view --repo tas50/cinc-cli --json tagName -q .tagName" ]; then
+  echo "v9.9.9"
+  exit 0
+fi
+
+echo "unexpected gh arguments: $*" >&2
+exit 1
+EOF
+
+  chmod +x "${tmpdir}/bin/gh"
+
+  local output_file="${tmpdir}/outputs"
+  PATH="${tmpdir}/bin:${PATH}" \
+    GITHUB_OUTPUT="${output_file}" \
+    RUNNER_OS="Linux" \
+    RUNNER_ARCH="X64" \
+    CINC_DISTRIBUTION="${distribution}" \
+    CINC_VERSION="${version}" \
+    CINC_CHANNEL="stable" \
+    bash "${scripts_dir}/resolve-inputs.sh"
+
+  assert_output "${output_file}" "distribution" "${distribution}"
+  assert_output "${output_file}" "requested_version" "${expected_version}"
+  assert_output "${output_file}" "channel" "stable"
+  assert_output "${output_file}" "runner_os" "Linux"
+  assert_output "${output_file}" "runner_arch" "X64"
+}
+
+echo "::group::Checking install-workstation action contract"
+echo "action_file=${action_file}"
+echo "scripts_dir=${scripts_dir}"
+
+# Keep action.yml as orchestration. Implementation should stay in scripts so
+# Bash linting, PowerShell parsing, and focused contract tests can run directly.
+assert_contains "${action_file}" "\$GITHUB_ACTION_PATH/scripts/install-unix.sh"
+assert_contains "${action_file}" "\$GITHUB_ACTION_PATH/scripts/install-cinc-cli.sh"
+assert_contains "${action_file}" "\$GITHUB_ACTION_PATH/scripts/outputs-unix.sh"
+assert_contains "${action_file}" "\$env:GITHUB_ACTION_PATH/scripts/install-windows.ps1"
+assert_contains "${action_file}" "\$env:GITHUB_ACTION_PATH/scripts/refresh-windows-path.ps1"
+assert_contains "${action_file}" "\$env:GITHUB_ACTION_PATH/scripts/outputs-windows.ps1"
+assert_contains "${action_file}" "outputs:"
+assert_contains "${action_file}" "version:"
+assert_contains "${action_file}" "executable:"
+assert_contains "${action_file}" "executable_path:"
+assert_contains "${action_file}" "cinc_path:"
+assert_contains "${action_file}" "chef_path:"
+assert_contains "${action_file}" "knife_path:"
+assert_contains "${action_file}" "runner_os:"
+assert_contains "${action_file}" "runner_arch:"
+assert_contains "${action_file}" "steps.outputs-unix.outputs.version || steps.outputs-windows.outputs.version"
+
+for script in "${scripts_dir}"/*.sh; do
+  assert_contains "${script}" "#!/usr/bin/env bash"
+  assert_contains "${script}" "set -euo pipefail"
+done
+
+for script in "${scripts_dir}"/*.ps1; do
+  assert_contains "${script}" "Set-StrictMode -Version Latest"
+  assert_contains "${script}" "\$ErrorActionPreference = 'Stop'"
+done
+
+assert_contains "${scripts_dir}/install-unix.sh" "-P cinc-workstation"
+assert_contains "${scripts_dir}/install-windows.ps1" "-project cinc-workstation"
+assert_contains "${scripts_dir}/install-cinc-cli.sh" "platform=\"darwin\""
+assert_contains "${scripts_dir}/install-cinc-cli.sh" "platform=\"linux\""
+assert_contains "${scripts_dir}/install-cinc-cli.sh" "arch=\"amd64\""
+assert_contains "${scripts_dir}/install-cinc-cli.sh" "arch=\"arm64\""
+assert_contains "${scripts_dir}/resolve-inputs.sh" "gh release view --repo tas50/cinc-cli"
+assert_contains "${scripts_dir}/refresh-windows-path.ps1" "\$env:GITHUB_PATH"
+assert_contains "${scripts_dir}/outputs-unix.sh" "emit_output \"version\""
+assert_contains "${scripts_dir}/outputs-unix.sh" "emit_output \"executable\""
+assert_contains "${scripts_dir}/outputs-unix.sh" "emit_output \"executable_path\""
+assert_contains "${scripts_dir}/outputs-unix.sh" "emit_output \"knife_path\""
+assert_contains "${scripts_dir}/outputs-windows.ps1" "Add-ActionOutput -Name version"
+assert_contains "${scripts_dir}/outputs-windows.ps1" "Add-ActionOutput -Name executable"
+assert_contains "${scripts_dir}/outputs-windows.ps1" "Add-ActionOutput -Name executable_path"
+assert_contains "${scripts_dir}/outputs-windows.ps1" "Add-ActionOutput -Name knife_path"
+
+echo "::endgroup::"
+
+echo "::group::Checking install-workstation output contracts"
+run_resolve_inputs_contract "workstation" "latest" "latest"
+run_resolve_inputs_contract "cinc-cli" "latest" "v9.9.9"
+run_outputs_unix_contract "workstation" "Chef Workstation 25.0.0" "chef"
+run_outputs_unix_contract "cinc-cli" "cinc 0.11.0" "cinc"
+echo "::endgroup::"

--- a/.github/actions/install-workstation/tests/check-script-contracts.sh
+++ b/.github/actions/install-workstation/tests/check-script-contracts.sh
@@ -58,7 +58,8 @@ EOF
 #!/usr/bin/env bash
 case "${1:-}" in
   --version|version)
-    echo "Chef Workstation 25.0.0"
+    echo "Redirecting to cinc" >&2
+    echo "Cinc Workstation version: 25.0.0"
     ;;
   *)
     echo "unexpected chef arguments: $*" >&2
@@ -185,6 +186,6 @@ echo "::endgroup::"
 echo "::group::Checking install-workstation output contracts"
 run_resolve_inputs_contract "workstation" "latest" "latest"
 run_resolve_inputs_contract "cinc-cli" "latest" "v9.9.9"
-run_outputs_unix_contract "workstation" "Chef Workstation 25.0.0" "chef"
+run_outputs_unix_contract "workstation" "Cinc Workstation version: 25.0.0" "chef"
 run_outputs_unix_contract "cinc-cli" "cinc 0.11.0" "cinc"
 echo "::endgroup::"

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -13,7 +13,7 @@ name: "Prevent file change reusable"
         description: Comma-separated list of trusted authors for metadata changes
         required: false
         type: string
-        default: &trusted_authors "bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima,renovate[bot]"
+        default: bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima,renovate[bot]
       workflow_pattern:
         description: Pattern of workflow files to monitor
         required: false
@@ -23,7 +23,7 @@ name: "Prevent file change reusable"
         description: Comma-separated list of trusted authors for workflow changes
         required: false
         type: string
-        default: *trusted_authors
+        default: bmhughes,damacus,kitchen-porter,MarkGibbons,ramereth,Stromweld,xorima,renovate[bot]
       workflow_close_pr:
         description: Close the PR if workflow files change
         required: false

--- a/.github/workflows/test-install-workstation.yml
+++ b/.github/workflows/test-install-workstation.yml
@@ -6,7 +6,9 @@ name: Test install-workstation action
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-latest
+    # This job only runs checkout plus a JavaScript action, so it can use the
+    # smaller runner without depending on preinstalled CLI tools.
+    runs-on: ubuntu-slim
     outputs:
       install-workstation: ${{ steps.filter.outputs.install-workstation }}
     steps:
@@ -19,6 +21,10 @@ jobs:
           filters: |
             install-workstation:
               - '.github/actions/install-workstation/**'
+      - name: Report changed path result
+        shell: bash
+        run: |
+          echo "install-workstation changed: ${{ steps.filter.outputs.install-workstation }}"
 
   test:
     needs: [detect-changes]
@@ -26,20 +32,129 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        version: ["24", "latest"]
+        include:
+          - os: ubuntu-latest
+            distribution: workstation
+            version: "24"
+            expected-command: chef
+          - os: ubuntu-latest
+            distribution: workstation
+            version: latest
+            expected-command: chef
+          - os: macos-latest
+            distribution: workstation
+            version: latest
+            expected-command: chef
+          - os: windows-latest
+            distribution: workstation
+            version: latest
+            expected-command: chef
+          - os: ubuntu-latest
+            distribution: cinc-cli
+            version: latest
+            expected-command: cinc
+          - os: macos-latest
+            distribution: cinc-cli
+            version: latest
+            expected-command: cinc
     runs-on: ${{ matrix.os }}
-    name: runner / install-workstation ${{ matrix.os }} v${{ matrix.version }}
+    name: runner / install ${{ matrix.distribution }} ${{ matrix.os }} v${{ matrix.version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-      - name: Install Cinc Workstation
+      - name: Install Cinc
+        id: install-cinc
         uses: ./.github/actions/install-workstation
         with:
+          distribution: ${{ matrix.distribution }}
           version: ${{ matrix.version }}
-      - name: Verify chef command is available
+      - name: Report action outputs
         shell: bash
-        run: chef --version
+        run: |
+          echo "distribution=${{ steps.install-cinc.outputs.distribution }}"
+          echo "requested_version=${{ steps.install-cinc.outputs.requested_version }}"
+          echo "version=${{ steps.install-cinc.outputs.version }}"
+          echo "channel=${{ steps.install-cinc.outputs.channel }}"
+          echo "runner_os=${{ steps.install-cinc.outputs.runner_os }}"
+          echo "runner_arch=${{ steps.install-cinc.outputs.runner_arch }}"
+          echo "executable=${{ steps.install-cinc.outputs.executable }}"
+          echo "executable_path=${{ steps.install-cinc.outputs.executable_path }}"
+          echo "cinc_path=${{ steps.install-cinc.outputs.cinc_path }}"
+          echo "chef_path=${{ steps.install-cinc.outputs.chef_path }}"
+          echo "knife_path=${{ steps.install-cinc.outputs.knife_path }}"
+      - name: Verify expected command is available
+        shell: bash
+        run: |
+          echo "PATH=${PATH}"
+          echo "${{ matrix.expected-command }}=$(command -v ${{ matrix.expected-command }})"
+          "${{ matrix.expected-command }}" --version || "${{ matrix.expected-command }}" version
+      - name: Verify required action outputs
+        shell: bash
+        run: |
+          test -n "${{ steps.install-cinc.outputs.distribution }}"
+          test -n "${{ steps.install-cinc.outputs.requested_version }}"
+          test -n "${{ steps.install-cinc.outputs.version }}"
+          test -n "${{ steps.install-cinc.outputs.runner_os }}"
+          test -n "${{ steps.install-cinc.outputs.runner_arch }}"
+          test -n "${{ steps.install-cinc.outputs.executable }}"
+          test -n "${{ steps.install-cinc.outputs.executable_path }}"
+
+  check-action-scripts:
+    # Keep this on ubuntu-latest because it relies on runner-provided shellcheck
+    # and pwsh. Those are not guaranteed on ubuntu-slim.
+    runs-on: ubuntu-latest
+    name: runner / action scripts
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Show script check tools
+        shell: bash
+        run: |
+          echo "bash=$(command -v bash)"
+          echo "shellcheck=$(command -v shellcheck)"
+          echo "pwsh=$(command -v pwsh)"
+          shellcheck --version
+      - name: Show PowerShell version
+        shell: pwsh
+        run: $PSVersionTable.PSVersion
+      - name: List action implementation files
+        shell: bash
+        run: find .github/actions/install-workstation -maxdepth 4 -type f -print | sort
+      - name: Run shellcheck
+        shell: bash
+        run: |
+          echo "::group::shellcheck install-workstation scripts"
+          shellcheck \
+            .github/actions/install-workstation/scripts/*.sh \
+            .github/actions/install-workstation/tests/*.sh
+          echo "::endgroup::"
+      - name: Run script contract tests
+        shell: bash
+        run: bash .github/actions/install-workstation/tests/check-script-contracts.sh
+      - name: Check PowerShell syntax
+        shell: pwsh
+        run: |
+          Write-Host 'Checking PowerShell parser errors for install-workstation scripts.'
+          $failed = $false
+          Get-ChildItem .github/actions/install-workstation/scripts -Filter *.ps1 | ForEach-Object {
+            Write-Host "Parsing $($_.FullName)"
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              $_.FullName,
+              [ref] $tokens,
+              [ref] $errors
+            ) > $null
+
+            if ($errors.Count -gt 0) {
+              $errors | Format-List
+              $failed = $true
+            }
+          }
+
+          if ($failed) {
+            exit 1
+          }
 
   check-markdown:
     runs-on: ubuntu-latest
@@ -71,15 +186,20 @@ jobs:
         uses: raven-actions/actionlint@v2
 
   final:
-    runs-on: ubuntu-latest
+    # This job only aggregates upstream job results, so it does not need the
+    # full ubuntu-latest toolset.
+    runs-on: ubuntu-slim
     name: final
-    needs: [test, check-markdown, check-yaml, check-workflows]
+    needs: [test, check-action-scripts, check-markdown, check-yaml, check-workflows]
     if: always()
     steps:
       - name: Check results
+        shell: bash
         run: |
+          echo "Aggregating install-workstation workflow results."
           declare -A results=(
             [test]="${{ needs.test.result }}"
+            [check-action-scripts]="${{ needs.check-action-scripts.result }}"
             [check-markdown]="${{ needs.check-markdown.result }}"
             [check-yaml]="${{ needs.check-yaml.result }}"
             [check-workflows]="${{ needs.check-workflows.result }}"


### PR DESCRIPTION
## Summary
- rebase the install-workstation composite action refactor on the latest main work
- keep action.yml as orchestration and move platform-specific behavior into focused scripts
- add distribution=workstation or distribution=cinc-cli, with Workstation as the default
- support cinc-cli install on Linux and macOS using release asset platform/architecture selection
- pull in PR #78 behavior: resolve cinc-cli latest dynamically with gh release view instead of hardcoding a tag
- add debuggable outputs: distribution, version, requested_version, channel, runner_os, runner_arch, executable, executable_path, cinc_path, chef_path, knife_path
- add runtime output contract tests for workstation and cinc-cli output resolution, plus fake-gh tests for latest version resolution
- add debuggable logs for installer inputs, discovered tools, PATH/command locations, script parsing, and contract checks
- use ubuntu-slim for low-risk orchestration jobs and document why tool-dependent checks stay on ubuntu-latest

## Verification
- gh pr diff 78 --patch
- gh api repos/tas50/cinc-cli/releases/tags/v0.11.0 --jq '.assets[].name'
- actionlint -no-color .github/workflows/*.yml
- shellcheck .github/actions/install-workstation/scripts/*.sh .github/actions/install-workstation/tests/*.sh
- bash .github/actions/install-workstation/tests/check-script-contracts.sh
- pwsh PowerShell parser pass for install-workstation scripts
- yq '.' .github/actions/install-workstation/action.yml .github/workflows/test-install-workstation.yml
- markdownlint-cli2 .github/actions/README.md